### PR TITLE
Simple alarm() for _WIN32

### DIFF
--- a/include/compat_time.h
+++ b/include/compat_time.h
@@ -1,5 +1,5 @@
 /** @file
-    compat_time addresses compatibility time functions.
+    compat_time addresses compatibility time and alarm() functions.
 
     topic: high-resolution timestamps
     issue: <sys/time.h> is not available on Windows systems
@@ -12,6 +12,7 @@
 // ensure struct timeval is known
 #ifdef _WIN32
 #include <winsock2.h>
+#include <signal.h>
 #else
 #include <sys/time.h>
 #endif
@@ -29,6 +30,10 @@ int timeval_subtract(struct timeval *result, struct timeval *x, struct timeval *
 
 #ifdef _WIN32
 int gettimeofday(struct timeval *tv, void *tz);
+int win_alarm(unsigned seconds);
+
+#define alarm(sec)  win_alarm(sec)
+#define SIGALRM     SIGBREAK  /* No SIGUSRx on Windows. Use this */
 #endif
 
 #endif  /* INCLUDE_COMPAT_TIME_H_ */


### PR DESCRIPTION
Add prototype for `win_alarm()`.
Define `SIGALRM` as `SIGBREAK` since the latter is unused.