### PR TITLE
Fix "-Wextra-semi-stmt" (3)

### DIFF
--- a/src/devices/missil_ml0757.c
+++ b/src/devices/missil_ml0757.c
@@ -51,8 +51,8 @@ All packets begin with an empty row in addition to the 9 rows of repeated data.
 
 #include "decoder.h"
 
-#define MISSIL_ML0757_FLAG_RWP  0x04; // Rain+Wind packet flag
-#define MISSIL_ML0757_FLAG_BAT  0x80; // Battery low flag
+#define MISSIL_ML0757_FLAG_RWP  0x04 // Rain+Wind packet flag
+#define MISSIL_ML0757_FLAG_BAT  0x80 // Battery low flag
 
 static int missil_ml0757_callback(r_device *decoder, bitbuffer_t *bitbuffer)
 {

--- a/src/devices/rojaflex.c
+++ b/src/devices/rojaflex.c
@@ -124,7 +124,7 @@ static int rojaflex_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 fprintf(stderr, "%s: CRC invalid message:%04x != calc:%04x\n", __func__, crc_message, crc_calc);
 
             return DECODE_FAIL_MIC;
-        };
+        }
     }
 
     // Data output


### PR DESCRIPTION
Another clang-cl `-Wextra-semi-stmt` fix.